### PR TITLE
Remove schema creation script tool package from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A stream store library for .NET that specifically targets SQL based implementati
 | [MySQL](https://www.nuget.org/packages/SqlStreamStore.MySql) / AWS Aurora | [![NuGet](https://img.shields.io/nuget/vpre/SqlStreamStore.MySql.svg?logo=nuget)](https://www.nuget.org/packages/SqlStreamStore.MySql) |
 | Sqlite | [_up for grabs_](https://github.com/SQLStreamStore/SqlStreamStore/issues/28) |
 | HTTP Wrapper API | On CI Feed |
-| [Schema Creation Script Tool](https://www.fuget.org/packages/SqlStreamStore.SchemaCreationScriptTool) | [![NuGet](https://img.shields.io/nuget/v/SqlStreamStore.SchemaCreationScriptTool.svg?logo=nuget)](https://www.nuget.org/packages/SqlStreamStore.SchemaCreationScriptTool) |
 
 CI Packages available [on Feedz](https://f.feedz.io/logicality/streamstore-ci/nuget/index.json).
 


### PR DESCRIPTION
It no longer appears to exist.

> ![package showing a not found icon](https://user-images.githubusercontent.com/2148318/156031039-bf9566e0-d835-4bba-b3aa-c58ddb1be9bf.png)

I looked around for it elsewhere but there does not appear to be one available any longer.